### PR TITLE
Block SSRF on ExternalProvider fetches

### DIFF
--- a/src/controllers/ExternalProviderController.ts
+++ b/src/controllers/ExternalProviderController.ts
@@ -4,7 +4,7 @@ import { LessonsBaseController } from "./LessonsBaseController";
 import { Provider } from "../models";
 import { Permissions } from "../helpers/Permissions";
 import { ExternalProviderHelper } from "../helpers/ExternalProviderHelper";
-import axios from "axios";
+import { fetchProviderJson } from "../helpers/ProviderUrlHelper";
 
 @controller("/externalProviders")
 export class ExternalProviderController extends LessonsBaseController {
@@ -20,8 +20,7 @@ export class ExternalProviderController extends LessonsBaseController {
   public async getPublicLessons(@requestParam("id") id: string, req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapperAnon(req, res, async () => {
       const ep = await this.repositories.externalProvider.loadPublic(id);
-      const data = (await axios.get(ep.apiUrl)).data;
-      return data;
+      return await fetchProviderJson(ep.apiUrl);
     });
   }
 

--- a/src/helpers/ExternalProviderHelper.ts
+++ b/src/helpers/ExternalProviderHelper.ts
@@ -1,5 +1,5 @@
 import { Repositories } from "../repositories";
-import { ArrayHelper } from ".";
+import { ArrayHelper } from "@churchapps/apihelper";
 import { fetchProviderJson, providerHostname } from "./ProviderUrlHelper";
 
 export class ExternalProviderHelper {

--- a/src/helpers/ExternalProviderHelper.ts
+++ b/src/helpers/ExternalProviderHelper.ts
@@ -1,6 +1,6 @@
 import { Repositories } from "../repositories";
-import axios from "axios";
 import { ArrayHelper } from ".";
+import { fetchProviderJson, providerHostname } from "./ProviderUrlHelper";
 
 export class ExternalProviderHelper {
   // Converts external venue data to planItems format matching /venues/public/planItems/:id response
@@ -75,7 +75,7 @@ export class ExternalProviderHelper {
   // Loads external venue data and returns both the data and venue name
   public static async loadExternalDataWithVenueName(externalProviderId: string, venueId: string) {
     const ep = await Repositories.getCurrent().externalProvider.loadPublic(externalProviderId);
-    const data = (await axios.get(ep.apiUrl)).data;
+    const data = await fetchProviderJson(ep.apiUrl);
 
     let venue = null;
     data.programs.forEach((program: any) => {
@@ -90,7 +90,7 @@ export class ExternalProviderHelper {
 
     if (!venue) throw new Error("Could not load venue: " + venueId);
     else {
-      const result = (await axios.get(venue.apiUrl)).data;
+      const result = await fetchProviderJson(venue.apiUrl, [providerHostname(ep.apiUrl)]);
       return { data: result, venueName: venue.name };
     }
   }
@@ -117,7 +117,7 @@ export class ExternalProviderHelper {
 
   public static async loadExternalData(externalProviderId: string, programId: string, studyId: string, lessonId: string, venueId: string) {
     const ep = await Repositories.getCurrent().externalProvider.loadPublic(externalProviderId);
-    const data = (await axios.get(ep.apiUrl)).data;
+    const data = await fetchProviderJson(ep.apiUrl);
     let venue = null;
 
     const program = ArrayHelper.getOne(data.programs, "id", programId);
@@ -133,14 +133,13 @@ export class ExternalProviderHelper {
 
     if (!venue) throw new Error("Could not load venue: " + venueId);
     else {
-      const result = (await axios.get(venue.apiUrl)).data;
-      return result;
+      return await fetchProviderJson(venue.apiUrl, [providerHostname(ep.apiUrl)]);
     }
   }
 
   public static async loadExternalDataById(externalProviderId: string, venueId: string) {
     const ep = await Repositories.getCurrent().externalProvider.loadPublic(externalProviderId);
-    const data = (await axios.get(ep.apiUrl)).data;
+    const data = await fetchProviderJson(ep.apiUrl);
 
     let venue = null;
     data.programs.forEach((program: any) => {
@@ -155,8 +154,7 @@ export class ExternalProviderHelper {
 
     if (!venue) throw new Error("Could not load venue: " + venueId);
     else {
-      const result = (await axios.get(venue.apiUrl)).data;
-      return result;
+      return await fetchProviderJson(venue.apiUrl, [providerHostname(ep.apiUrl)]);
     }
   }
 }

--- a/src/helpers/ProviderUrlHelper.ts
+++ b/src/helpers/ProviderUrlHelper.ts
@@ -1,0 +1,66 @@
+import axios from "axios";
+import dns from "dns/promises";
+import { BlockList, isIP } from "net";
+
+const TRUSTED_HOST_SUFFIXES = ["lessons.church"];
+const BLOCKED_HOSTS = new Set(["localhost", "localhost.localdomain", "metadata", "metadata.google.internal", "metadata.google.com"]);
+const BLOCKED_HOST_SUFFIXES = [".localhost", ".local", ".internal", ".lan", ".home", ".corp", ".private", ".localdomain", ".invalid"];
+
+const blocked = new BlockList();
+blocked.addSubnet("0.0.0.0", 8, "ipv4");
+blocked.addSubnet("10.0.0.0", 8, "ipv4");
+blocked.addSubnet("100.64.0.0", 10, "ipv4");
+blocked.addSubnet("127.0.0.0", 8, "ipv4");
+blocked.addSubnet("169.254.0.0", 16, "ipv4");
+blocked.addSubnet("172.16.0.0", 12, "ipv4");
+blocked.addSubnet("192.168.0.0", 16, "ipv4");
+blocked.addSubnet("198.18.0.0", 15, "ipv4");
+blocked.addSubnet("224.0.0.0", 4, "ipv4");
+blocked.addAddress("255.255.255.255", "ipv4");
+blocked.addAddress("::", "ipv6");
+blocked.addAddress("::1", "ipv6");
+blocked.addSubnet("fc00::", 7, "ipv6");
+blocked.addSubnet("fe80::", 10, "ipv6");
+blocked.addSubnet("ff00::", 8, "ipv6");
+
+function normalizeHost(hostname: string) {
+  return hostname.replace(/\.$/, "").toLowerCase();
+}
+
+function isTrustedHost(hostname: string) {
+  return TRUSTED_HOST_SUFFIXES.some(suffix => hostname === suffix || hostname.endsWith("." + suffix));
+}
+
+function isBlockedHostname(hostname: string) {
+  if (BLOCKED_HOSTS.has(hostname)) return true;
+  return BLOCKED_HOST_SUFFIXES.some(suffix => hostname.endsWith(suffix));
+}
+
+function isBlockedAddress(address: string) {
+  const ip = address.startsWith("::ffff:") ? address.slice(7) : address;
+  const family = ip.includes(":") ? "ipv6" : "ipv4";
+  return blocked.check(ip, family);
+}
+
+export function providerHostname(rawUrl: string) {
+  return normalizeHost(new URL(rawUrl).hostname);
+}
+
+export async function assertSafeProviderUrl(rawUrl: string, extraAllowedHosts?: string[]) {
+  if (!rawUrl || typeof rawUrl !== "string") throw new Error("Invalid provider URL");
+  let parsed: URL;
+  try { parsed = new URL(rawUrl); } catch { throw new Error("Invalid provider URL"); }
+  if (parsed.protocol !== "https:") throw new Error("Provider URL must be https");
+  if (parsed.username || parsed.password) throw new Error("Invalid provider URL");
+  const hostname = normalizeHost(parsed.hostname);
+  if (!hostname || isIP(hostname) || isBlockedHostname(hostname)) throw new Error("Provider URL host is not allowed");
+  if (extraAllowedHosts && !isTrustedHost(hostname) && !extraAllowedHosts.map(normalizeHost).includes(hostname)) throw new Error("Provider URL host is not allowed");
+  const addresses = await dns.lookup(hostname, { all: true });
+  if (!addresses.length || addresses.some(a => isBlockedAddress(a.address))) throw new Error("Provider URL host is not allowed");
+}
+
+export async function fetchProviderJson(rawUrl: string, extraAllowedHosts?: string[]) {
+  await assertSafeProviderUrl(rawUrl, extraAllowedHosts);
+  const response = await axios.get(rawUrl, { maxRedirects: 0, timeout: 10000, validateStatus: status => status >= 200 && status < 300 });
+  return response.data;
+}

--- a/src/helpers/ProviderUrlHelper.ts
+++ b/src/helpers/ProviderUrlHelper.ts
@@ -4,7 +4,9 @@ import { BlockList, isIP } from "net";
 
 const TRUSTED_HOST_SUFFIXES = ["lessons.church"];
 const BLOCKED_HOSTS = new Set(["localhost", "localhost.localdomain", "metadata", "metadata.google.internal", "metadata.google.com"]);
-const BLOCKED_HOST_SUFFIXES = [".localhost", ".local", ".internal", ".lan", ".home", ".corp", ".private", ".localdomain", ".invalid"];
+const BLOCKED_HOST_SUFFIXES = [
+  ".localhost", ".local", ".internal", ".lan", ".home", ".corp", ".private", ".localdomain", ".invalid"
+];
 
 const blocked = new BlockList();
 blocked.addSubnet("0.0.0.0", 8, "ipv4");
@@ -52,11 +54,11 @@ export async function assertSafeProviderUrl(rawUrl: string, extraAllowedHosts?: 
   try { parsed = new URL(rawUrl); } catch { throw new Error("Invalid provider URL"); }
   if (parsed.protocol !== "https:") throw new Error("Provider URL must be https");
   if (parsed.username || parsed.password) throw new Error("Invalid provider URL");
-  const hostname = normalizeHost(parsed.hostname);
+  const hostname = normalizeHost(parsed.hostname.replace(/^\[|\]$/g, ""));
   if (!hostname || isIP(hostname) || isBlockedHostname(hostname)) throw new Error("Provider URL host is not allowed");
   if (extraAllowedHosts && !isTrustedHost(hostname) && !extraAllowedHosts.map(normalizeHost).includes(hostname)) throw new Error("Provider URL host is not allowed");
-  const addresses = await dns.lookup(hostname, { all: true });
-  if (!addresses.length || addresses.some(a => isBlockedAddress(a.address))) throw new Error("Provider URL host is not allowed");
+  const addresses = await dns.lookup(hostname, { all: true }).catch(() => []);
+  if (!addresses?.length || addresses.some(a => isBlockedAddress(a.address))) throw new Error("Provider URL host is not allowed");
 }
 
 export async function fetchProviderJson(rawUrl: string, extraAllowedHosts?: string[]) {

--- a/src/helpers/ProviderUrlHelper.ts
+++ b/src/helpers/ProviderUrlHelper.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import dns from "dns/promises";
-import { BlockList, isIP } from "net";
+import https from "https";
+import { BlockList, isIP, LookupFunction } from "net";
 
 const TRUSTED_HOST_SUFFIXES = ["lessons.church"];
 const BLOCKED_HOSTS = new Set(["localhost", "localhost.localdomain", "metadata", "metadata.google.internal", "metadata.google.com"]);
@@ -44,6 +45,26 @@ function isBlockedAddress(address: string) {
   return blocked.check(ip, family);
 }
 
+async function resolveAllowedAddresses(hostname: string) {
+  const addresses = await dns.lookup(hostname, { all: true }).catch(() => []);
+  if (!addresses?.length || addresses.some(a => isBlockedAddress(a.address))) throw new Error("Provider URL host is not allowed");
+  return addresses;
+}
+
+// Used as the socket's own lookup so the connection binds to the address this check approved.
+// Re-resolving inside the connect path removes the DNS rebinding window between validation and connect.
+export const safeProviderLookup: LookupFunction = (hostname, options, callback) => {
+  resolveAllowedAddresses(normalizeHost(hostname)).then(addresses => {
+    const family = typeof options?.family === "number" ? options.family : 0;
+    const matches = family === 4 || family === 6 ? addresses.filter(a => a.family === family) : addresses;
+    if (!matches.length) throw new Error("Provider URL host is not allowed");
+    if (options?.all) callback(null, matches);
+    else callback(null, matches[0].address, matches[0].family);
+  }).catch(err => { callback(err as NodeJS.ErrnoException, ""); });
+};
+
+const providerAgent = new https.Agent({ lookup: safeProviderLookup });
+
 export function providerHostname(rawUrl: string) {
   return normalizeHost(new URL(rawUrl).hostname);
 }
@@ -57,12 +78,11 @@ export async function assertSafeProviderUrl(rawUrl: string, extraAllowedHosts?: 
   const hostname = normalizeHost(parsed.hostname.replace(/^\[|\]$/g, ""));
   if (!hostname || isIP(hostname) || isBlockedHostname(hostname)) throw new Error("Provider URL host is not allowed");
   if (extraAllowedHosts && !isTrustedHost(hostname) && !extraAllowedHosts.map(normalizeHost).includes(hostname)) throw new Error("Provider URL host is not allowed");
-  const addresses = await dns.lookup(hostname, { all: true }).catch(() => []);
-  if (!addresses?.length || addresses.some(a => isBlockedAddress(a.address))) throw new Error("Provider URL host is not allowed");
+  await resolveAllowedAddresses(hostname);
 }
 
 export async function fetchProviderJson(rawUrl: string, extraAllowedHosts?: string[]) {
   await assertSafeProviderUrl(rawUrl, extraAllowedHosts);
-  const response = await axios.get(rawUrl, { maxRedirects: 0, timeout: 10000, validateStatus: status => status >= 200 && status < 300 });
+  const response = await axios.get(rawUrl, { httpsAgent: providerAgent, maxRedirects: 0, timeout: 10000, validateStatus: status => status >= 200 && status < 300 });
   return response.data;
 }

--- a/src/helpers/__tests__/ExternalProviderHelper.test.ts
+++ b/src/helpers/__tests__/ExternalProviderHelper.test.ts
@@ -1,0 +1,47 @@
+jest.mock("../../repositories", () => ({ Repositories: { getCurrent: jest.fn() } }));
+jest.mock("../ProviderUrlHelper", () => ({
+  fetchProviderJson: jest.fn(),
+  providerHostname: (url: string) => new URL(url).hostname
+}));
+
+import { ExternalProviderHelper } from "../ExternalProviderHelper";
+import { Repositories } from "../../repositories";
+import { fetchProviderJson } from "../ProviderUrlHelper";
+
+const fetchJson = fetchProviderJson as jest.Mock;
+
+const tree = {
+  programs: [{
+    id: "p1",
+    studies: [{
+      id: "s1",
+      lessons: [{
+        id: "l1",
+        venues: [{ id: "v1", name: "Kids", apiUrl: "https://api.lessons.church/venues/public/feed/v1" }]
+      }]
+    }]
+  }]
+};
+
+describe("ExternalProviderHelper.loadExternalData", () => {
+  beforeEach(() => {
+    fetchJson.mockReset();
+    (Repositories.getCurrent as jest.Mock).mockReturnValue({
+      externalProvider: { loadPublic: jest.fn(async () => ({ id: "ep1", apiUrl: "https://api.lessons.church/lessons/public/tree" })) }
+    });
+  });
+
+  it("loads the tree then the venue feed on the provider host", async () => {
+    fetchJson.mockResolvedValueOnce(tree).mockResolvedValueOnce({ lessonName: "Creation" });
+    const result = await ExternalProviderHelper.loadExternalData("ep1", "p1", "s1", "l1", "v1");
+    expect(result.lessonName).toBe("Creation");
+    expect(fetchJson).toHaveBeenNthCalledWith(1, "https://api.lessons.church/lessons/public/tree");
+    expect(fetchJson).toHaveBeenNthCalledWith(2, "https://api.lessons.church/venues/public/feed/v1", ["api.lessons.church"]);
+  });
+
+  it("does not fetch a venue URL when the tree request is rejected", async () => {
+    fetchJson.mockRejectedValueOnce(new Error("Provider URL host is not allowed"));
+    await expect(ExternalProviderHelper.loadExternalData("ep1", "p1", "s1", "l1", "v1")).rejects.toThrow("not allowed");
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/helpers/__tests__/ExternalProviderHelper.test.ts
+++ b/src/helpers/__tests__/ExternalProviderHelper.test.ts
@@ -3,6 +3,10 @@ jest.mock("../ProviderUrlHelper", () => ({
   fetchProviderJson: jest.fn(),
   providerHostname: (url: string) => new URL(url).hostname
 }));
+jest.mock("@churchapps/apihelper", () => ({
+  __esModule: true,
+  ArrayHelper: { getOne: (items: any[], key: string, value: any) => (items || []).find((i: any) => i[key] === value) }
+}));
 
 import { ExternalProviderHelper } from "../ExternalProviderHelper";
 import { Repositories } from "../../repositories";
@@ -11,24 +15,28 @@ import { fetchProviderJson } from "../ProviderUrlHelper";
 const fetchJson = fetchProviderJson as jest.Mock;
 
 const tree = {
-  programs: [{
-    id: "p1",
-    studies: [{
-      id: "s1",
-      lessons: [{
-        id: "l1",
-        venues: [{ id: "v1", name: "Kids", apiUrl: "https://api.lessons.church/venues/public/feed/v1" }]
-      }]
-    }]
-  }]
+  programs: [
+    {
+      id: "p1",
+      studies: [
+        {
+          id: "s1",
+          lessons: [
+            {
+              id: "l1",
+              venues: [{ id: "v1", name: "Kids", apiUrl: "https://api.lessons.church/venues/public/feed/v1" }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 };
 
 describe("ExternalProviderHelper.loadExternalData", () => {
   beforeEach(() => {
     fetchJson.mockReset();
-    (Repositories.getCurrent as jest.Mock).mockReturnValue({
-      externalProvider: { loadPublic: jest.fn(async () => ({ id: "ep1", apiUrl: "https://api.lessons.church/lessons/public/tree" })) }
-    });
+    (Repositories.getCurrent as jest.Mock).mockReturnValue({ externalProvider: { loadPublic: jest.fn(async () => ({ id: "ep1", apiUrl: "https://api.lessons.church/lessons/public/tree" })) } });
   });
 
   it("loads the tree then the venue feed on the provider host", async () => {

--- a/src/helpers/__tests__/ProviderUrlHelper.test.ts
+++ b/src/helpers/__tests__/ProviderUrlHelper.test.ts
@@ -1,0 +1,94 @@
+jest.mock("axios", () => ({ get: jest.fn() }));
+jest.mock("dns/promises", () => ({ lookup: jest.fn() }));
+
+import axios from "axios";
+import dns from "dns/promises";
+import { assertSafeProviderUrl, fetchProviderJson, providerHostname } from "../ProviderUrlHelper";
+
+const lookup = dns.lookup as jest.Mock;
+const axiosGet = axios.get as jest.Mock;
+
+function publicLookup(hostname: string) {
+  lookup.mockResolvedValue([{ address: "203.0.113.10", family: 4 }]);
+  return hostname;
+}
+
+describe("assertSafeProviderUrl", () => {
+  beforeEach(() => {
+    lookup.mockReset();
+    axiosGet.mockReset();
+  });
+
+  it("allows https lesson provider hosts that resolve publicly", async () => {
+    publicLookup("api.lessons.church");
+    await expect(assertSafeProviderUrl("https://api.lessons.church/lessons/public/tree")).resolves.toBeUndefined();
+    publicLookup("api.staging.lessons.church");
+    await expect(assertSafeProviderUrl("https://api.staging.lessons.church/lessons/public/tree")).resolves.toBeUndefined();
+    publicLookup("curriculum.example.org");
+    await expect(assertSafeProviderUrl("https://curriculum.example.org/feed.json")).resolves.toBeUndefined();
+  });
+
+  it("rejects http, credentials, and invalid URLs", async () => {
+    await expect(assertSafeProviderUrl("http://api.lessons.church/feed")).rejects.toThrow("https");
+    await expect(assertSafeProviderUrl("https://user:pass@api.lessons.church/feed")).rejects.toThrow("Invalid provider URL");
+    await expect(assertSafeProviderUrl("not-a-url")).rejects.toThrow("Invalid provider URL");
+    await expect(assertSafeProviderUrl("")).rejects.toThrow("Invalid provider URL");
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects private, link-local, and metadata targets", async () => {
+    await expect(assertSafeProviderUrl("https://127.0.0.1/latest")).rejects.toThrow("not allowed");
+    await expect(assertSafeProviderUrl("https://169.254.169.254/latest/meta-data")).rejects.toThrow("not allowed");
+    await expect(assertSafeProviderUrl("https://10.0.0.8/admin")).rejects.toThrow("not allowed");
+    await expect(assertSafeProviderUrl("https://192.168.1.1/")).rejects.toThrow("not allowed");
+    await expect(assertSafeProviderUrl("https://[::1]/")).rejects.toThrow("not allowed");
+    await expect(assertSafeProviderUrl("https://localhost/feed")).rejects.toThrow("not allowed");
+    await expect(assertSafeProviderUrl("https://metadata.google.internal/")).rejects.toThrow("not allowed");
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects hosts that resolve to private or link-local addresses", async () => {
+    lookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+    await expect(assertSafeProviderUrl("https://rebind.example/feed")).rejects.toThrow("not allowed");
+    lookup.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    await expect(assertSafeProviderUrl("https://meta.example/feed")).rejects.toThrow("not allowed");
+    lookup.mockResolvedValue([{ address: "203.0.113.10", family: 4 }, { address: "10.1.2.3", family: 4 }]);
+    await expect(assertSafeProviderUrl("https://mixed.example/feed")).rejects.toThrow("not allowed");
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects venue hosts outside the provider host and lessons.church", async () => {
+    publicLookup("evil.example");
+    await expect(assertSafeProviderUrl("https://evil.example/venue", ["curriculum.example.org"])).rejects.toThrow("not allowed");
+    publicLookup("api.lessons.church");
+    await expect(assertSafeProviderUrl("https://api.lessons.church/venues/public/feed/v1", ["curriculum.example.org"])).resolves.toBeUndefined();
+    publicLookup("curriculum.example.org");
+    await expect(assertSafeProviderUrl("https://curriculum.example.org/venues/v1", ["curriculum.example.org"])).resolves.toBeUndefined();
+  });
+});
+
+describe("fetchProviderJson", () => {
+  beforeEach(() => {
+    lookup.mockReset();
+    axiosGet.mockReset();
+  });
+
+  it("fetches allowlisted https URLs with redirects disabled", async () => {
+    publicLookup("api.lessons.church");
+    axiosGet.mockResolvedValue({ data: { programs: [] } });
+    await expect(fetchProviderJson("https://api.lessons.church/lessons/public/tree")).resolves.toEqual({ programs: [] });
+    expect(axiosGet).toHaveBeenCalledWith("https://api.lessons.church/lessons/public/tree", expect.objectContaining({ maxRedirects: 0 }));
+  });
+
+  it("does not fetch private or internal URLs", async () => {
+    await expect(fetchProviderJson("https://169.254.169.254/latest/meta-data")).rejects.toThrow("not allowed");
+    await expect(fetchProviderJson("http://127.0.0.1/")).rejects.toThrow();
+    expect(axiosGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("providerHostname", () => {
+  it("returns the normalized host", () => {
+    expect(providerHostname("https://API.Lessons.Church/lessons/public/tree")).toBe("api.lessons.church");
+  });
+});

--- a/src/helpers/__tests__/ProviderUrlHelper.test.ts
+++ b/src/helpers/__tests__/ProviderUrlHelper.test.ts
@@ -3,7 +3,7 @@ jest.mock("dns/promises", () => ({ lookup: jest.fn() }));
 
 import axios from "axios";
 import dns from "dns/promises";
-import { assertSafeProviderUrl, fetchProviderJson, providerHostname } from "../ProviderUrlHelper";
+import { assertSafeProviderUrl, fetchProviderJson, providerHostname, safeProviderLookup } from "../ProviderUrlHelper";
 
 const lookup = dns.lookup as jest.Mock;
 const axiosGet = axios.get as jest.Mock;
@@ -84,6 +84,56 @@ describe("fetchProviderJson", () => {
     await expect(fetchProviderJson("https://169.254.169.254/latest/meta-data")).rejects.toThrow("not allowed");
     await expect(fetchProviderJson("http://127.0.0.1/")).rejects.toThrow();
     expect(axiosGet).not.toHaveBeenCalled();
+  });
+
+  it("connects through an agent that re-checks the address it dials", async () => {
+    publicLookup("api.lessons.church");
+    axiosGet.mockResolvedValue({ data: {} });
+    await fetchProviderJson("https://api.lessons.church/lessons/public/tree");
+    expect(axiosGet.mock.calls[0][1].httpsAgent.options.lookup).toBe(safeProviderLookup);
+  });
+
+  it("blocks a rebind that flips to a private address after validation", async () => {
+    lookup.mockResolvedValueOnce([{ address: "203.0.113.10", family: 4 }]);
+    lookup.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    // Stand in for the socket: dial using the agent's lookup rather than a second bare resolve.
+    axiosGet.mockImplementation((url: string, config: any) => new Promise((resolve, reject) => {
+      config.httpsAgent.options.lookup(new URL(url).hostname, { all: true, family: 0 }, (err: Error) => (err ? reject(err) : resolve({ data: {} })));
+    }));
+    await expect(fetchProviderJson("https://rebind.example/feed")).rejects.toThrow("not allowed");
+  });
+});
+
+describe("safeProviderLookup", () => {
+  beforeEach(() => lookup.mockReset());
+
+  function callLookup(hostname: string, options: any) {
+    return new Promise<any>((resolve, reject) => {
+      safeProviderLookup(hostname, options, (err, address, family) => (err ? reject(err) : resolve({ address, family })));
+    });
+  }
+
+  it("returns the checked addresses in both single and all forms", async () => {
+    lookup.mockResolvedValue([{ address: "203.0.113.10", family: 4 }, { address: "2001:db8::1", family: 6 }]);
+    await expect(callLookup("curriculum.example.org", { family: 0 })).resolves.toEqual({ address: "203.0.113.10", family: 4 });
+    await expect(callLookup("curriculum.example.org", { all: true, family: 0 })).resolves.toEqual({ address: [{ address: "203.0.113.10", family: 4 }, { address: "2001:db8::1", family: 6 }], family: undefined });
+    await expect(callLookup("curriculum.example.org", { family: 6 })).resolves.toEqual({ address: "2001:db8::1", family: 6 });
+  });
+
+  it("errors instead of dialing private, link-local, or unresolvable hosts", async () => {
+    lookup.mockResolvedValue([{ address: "203.0.113.10", family: 4 }, { address: "127.0.0.1", family: 4 }]);
+    await expect(callLookup("mixed.example", { family: 0 })).rejects.toThrow("not allowed");
+    lookup.mockResolvedValue([{ address: "::ffff:169.254.169.254", family: 6 }]);
+    await expect(callLookup("meta.example", { family: 0 })).rejects.toThrow("not allowed");
+    lookup.mockResolvedValue([]);
+    await expect(callLookup("nxdomain.example", { family: 0 })).rejects.toThrow("not allowed");
+    lookup.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(callLookup("nxdomain.example", { family: 0 })).rejects.toThrow("not allowed");
+  });
+
+  it("errors when no checked address matches the requested family", async () => {
+    lookup.mockResolvedValue([{ address: "203.0.113.10", family: 4 }]);
+    await expect(callLookup("curriculum.example.org", { family: 6 })).rejects.toThrow("not allowed");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Anonymous ExternalProvider routes were doing `axios.get(ep.apiUrl)` and a second hop to `venue.apiUrl` from that JSON, with no scheme/host checks, no private-IP block, and default redirect following.

**What changed**
- All server-side provider fetches go through `fetchProviderJson`.
- HTTPS only; credentials, IP literals, localhost, and metadata-style hosts are rejected.
- DNS is resolved before the request; private, link-local, loopback, CGNAT, and multicast answers are rejected.
- Redirects are disabled (`maxRedirects: 0`).
- The venue hop must be the same host as the stored provider URL, or a `*.lessons.church` host.

**Why this shape**
LessonsApp portal/player callers use `/externalProviders/:id/lessons`, `/playlist/...`, and venue plan/action routes. First-party trees and venue feeds live on `api.lessons.church` (and staging). Churches can also add Open Lesson Format feeds on their own hosts, so the first hop allows any public HTTPS DNS name after the IP checks. A hostile provider document cannot send the Lambda to an internal URL or to a different public host.

Public playlist/player routes stay anonymous; they only fetch URLs that pass the same checks.

**Not in this PR**
FreeShow and SignPresenter are untouched.

Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14ecf7b6-c4ef-4ff8-b492-da1481a1b13e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14ecf7b6-c4ef-4ff8-b492-da1481a1b13e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

