### PR TITLE
Bind download records to the caller’s church

### DIFF
--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -12,21 +12,18 @@ export class DownloadController extends LessonsBaseController {
     return this.actionWrapper(req, res, async au => {
       const promises: Promise<Download>[] = [];
       req.body.forEach(download => {
+        download.churchId = au.churchId;
+        download.userId = au.id;
         if (!download.id) {
           download.ipAddress = (req.headers["x-forwarded-for"] || req.socket.remoteAddress).toString().split(",")[0];
           download.downloadDate = new Date();
         }
-        // Sanitize empty strings to undefined so they are stored as NULL
-        if (download.userId === "") download.userId = undefined;
-        if (download.churchId === "") download.churchId = undefined;
         promises.push(this.repositories.download.save(download));
       });
       const result = await Promise.all(promises);
-      // Only update HubSpot/Mautic if there's a valid churchId
-      if (req.body[0].churchId && req.body[0].churchId.trim() !== "") {
-        await this.updateHubspot(req.body[0].churchId);
-        // Awaits only the async-invoke enqueue (~50ms); the Mautic chain runs in the mauticSync Lambda
-        await MauticHelper.queueLessonDownload(req.body[0].churchId, req.body[0].lessonId, au);
+      if (au.churchId && au.churchId.trim() !== "") {
+        await this.updateHubspot(au.churchId);
+        await MauticHelper.queueLessonDownload(au.churchId, req.body[0].lessonId, au);
       }
       return result;
     });

--- a/src/controllers/__tests__/DownloadController.test.ts
+++ b/src/controllers/__tests__/DownloadController.test.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata";
+jest.mock("../LessonsBaseController", () => ({
+  LessonsBaseController: class {
+    repositories: any;
+    json(obj: any, status?: number) { return { obj, status: status ?? 200 }; }
+  }
+}));
+const queueLessonDownload = jest.fn(async () => {});
+jest.mock("../../helpers", () => ({
+  __esModule: true,
+  Environment: { hubspotKey: "" },
+  MauticHelper: { queueLessonDownload: (...args: any[]) => queueLessonDownload(...args) }
+}));
+jest.mock("../../helpers/HubspotHelper", () => ({
+  HubspotHelper: { lookupCompanByChurchId: jest.fn(), setProperties: jest.fn() }
+}));
+
+import { DownloadController } from "../DownloadController";
+
+function makeController(au: any, repos: any) {
+  const controller = new DownloadController();
+  (controller as any).actionWrapper = (_req: any, _res: any, action: any) => action(au);
+  (controller as any).repositories = repos;
+  return controller;
+}
+
+function req(body: any[]) {
+  return { body, headers: {}, socket: { remoteAddress: "1.2.3.4" } };
+}
+
+describe("DownloadController.save", () => {
+  beforeEach(() => queueLessonDownload.mockClear());
+
+  it("ignores a body churchId for another tenant", async () => {
+    const saved: any[] = [];
+    const repos = { download: { save: jest.fn(async (d: any) => { saved.push({ ...d }); return d; }), getDownloadCount: jest.fn() } };
+    const au = { churchId: "c1", id: "u1" };
+    const controller = makeController(au, repos);
+
+    await (controller as any).save(req([{ churchId: "OTHER", userId: "SPOOFED", lessonId: "l1" }]), {});
+
+    expect(saved[0].churchId).toBe("c1");
+    expect(saved[0].userId).toBe("u1");
+    expect(queueLessonDownload).toHaveBeenCalledWith("c1", "l1", au);
+    expect(queueLessonDownload).not.toHaveBeenCalledWith("OTHER", expect.anything(), expect.anything());
+  });
+});

--- a/src/repositories/DownloadRepository.ts
+++ b/src/repositories/DownloadRepository.ts
@@ -48,11 +48,10 @@ export class DownloadRepository {
       lessonId: download.lessonId,
       fileId: download.fileId,
       userId: download.userId,
-      churchId: download.churchId,
       ipAddress: download.ipAddress,
       downloadDate: download.downloadDate,
       fileName: download.fileName
-    }).where("id", "=", download.id).execute();
+    }).where("id", "=", download.id).where("churchId", "=", download.churchId).execute();
     return download;
   }
 

--- a/src/repositories/__tests__/DownloadRepository.test.ts
+++ b/src/repositories/__tests__/DownloadRepository.test.ts
@@ -1,0 +1,49 @@
+jest.mock("../../db", () => ({ getDb: jest.fn() }));
+jest.mock("../../helpers", () => ({
+  __esModule: true,
+  UniqueIdHelper: { shortId: () => "dl_gen", isMissing: (id?: string) => !id }
+}));
+
+import { getDb } from "../../db";
+import { DownloadRepository } from "../DownloadRepository";
+import { Download } from "../../models";
+
+const mockedGetDb = getDb as jest.Mock;
+
+describe("DownloadRepository.save", () => {
+  it("creates with a generated id and churchId", async () => {
+    const values = jest.fn().mockReturnValue({ execute: () => Promise.resolve() });
+    mockedGetDb.mockReturnValue({ insertInto: () => ({ values }) });
+
+    const download = await new DownloadRepository().save({ churchId: "c1", lessonId: "l1", userId: "u1" } as Download);
+
+    expect(download.id).toBe("dl_gen");
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ id: "dl_gen", churchId: "c1", lessonId: "l1", userId: "u1" }));
+  });
+
+  it("updates scoped to id and churchId", async () => {
+    const wheres: any[] = [];
+    const chain: any = { where: (...args: any[]) => { wheres.push(args); return chain; }, execute: () => Promise.resolve() };
+    const set = jest.fn().mockReturnValue(chain);
+    mockedGetDb.mockReturnValue({ updateTable: () => ({ set }) });
+
+    await new DownloadRepository().save({ id: "d1", churchId: "c1", lessonId: "l1", userId: "u1" } as Download);
+
+    expect(set).toHaveBeenCalledWith(expect.not.objectContaining({ churchId: expect.anything() }));
+    expect(wheres).toContainEqual(["id", "=", "d1"]);
+    expect(wheres).toContainEqual(["churchId", "=", "c1"]);
+  });
+});
+
+describe("DownloadRepository.delete", () => {
+  it("deletes scoped to id and churchId", async () => {
+    const wheres: any[] = [];
+    const chain: any = { where: (...args: any[]) => { wheres.push(args); return chain; }, execute: () => Promise.resolve([]) };
+    mockedGetDb.mockReturnValue({ deleteFrom: () => chain });
+
+    await new DownloadRepository().delete("c1", "d1");
+
+    expect(wheres).toContainEqual(["id", "=", "d1"]);
+    expect(wheres).toContainEqual(["churchId", "=", "c1"]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`POST /downloads` trusted the client `churchId`/`userId` and updated by id only. A signed-in user could attach download stats (and their HubSpot/Mautic contact) to another church or overwrite another tenant’s row.

**Fix**
- Stamp `churchId` and `userId` from the JWT (`au.churchId` / `au.id`). Client values are ignored.
- Scope `downloads` updates to `WHERE id = ? AND churchId = ?`. `churchId` is no longer writable on update. Delete was already church-scoped.
- HubSpot and Mautic enqueue only with `au.churchId`.

Anonymous playlist/classroom download logging is unchanged (those paths set church from the venue/schedule, not this route).

**Tests**
- Controller: a body `churchId` for another tenant is ignored; CRM is queued for the caller’s church.
- Repository: create keeps churchId; update/delete are scoped to id + churchId.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9e2bd5c-7d0d-4d02-8802-411737a5693c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9e2bd5c-7d0d-4d02-8802-411737a5693c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

