### PR TITLE
Scope cleanup and zip jobs to the caller’s church

### DIFF
--- a/src/controllers/BundleController.ts
+++ b/src/controllers/BundleController.ts
@@ -13,7 +13,7 @@ export class BundleController extends LessonsBaseController {
   public async zipAll(req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async au => {
       if (!au.checkAccess(Permissions.lessons.edit)) return this.json({}, 401);
-      await ZipHelper.zipPendingBundles();
+      await ZipHelper.zipPendingBundles(au.churchId);
       return [];
     });
   }
@@ -23,7 +23,7 @@ export class BundleController extends LessonsBaseController {
     return this.actionWrapper(req, res, async au => {
       if (!au.checkAccess(Permissions.lessons.edit)) return this.json({}, 401);
 
-      const pendingBundles = await this.repositories.bundle.loadPendingUpdate(50);
+      const pendingBundles = await this.repositories.bundle.loadPendingUpdate(50, au.churchId);
       const totalBundles = await this.repositories.bundle.loadAll(au.churchId);
 
       // Check for bundles that have been pending for too long (>1 hour)
@@ -57,7 +57,7 @@ export class BundleController extends LessonsBaseController {
     return this.actionWrapper(req, res, async au => {
       if (!au.checkAccess(Permissions.lessons.edit)) return this.json({}, 401);
 
-      const pendingBundles = await this.repositories.bundle.loadPendingUpdate(100);
+      const pendingBundles = await this.repositories.bundle.loadPendingUpdate(100, au.churchId);
       const stuckBundles = pendingBundles.filter(b => {
         const lastUpdate = new Date(b.dateModified || 0);
         const hourAgo = new Date(Date.now() - 60 * 60 * 1000);

--- a/src/controllers/FileController.ts
+++ b/src/controllers/FileController.ts
@@ -13,16 +13,34 @@ export class FileController extends LessonsBaseController {
   public async getCleanup(req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async au => {
       if (!au.checkAccess(Permissions.lessons.edit)) return this.json({}, 401);
-      await this.repositories.file.cleanUp();
-      const paths = await this.getOrphanedFiles();
+      const existing = await this.repositories.file.loadForChurch(au.churchId);
+      await this.repositories.file.cleanUp(au.churchId);
+      const paths = await this.getOrphanedFiles(au.churchId, existing);
       for (const p of paths) await FileStorageHelper.remove(p);
       return { paths };
     });
   }
 
-  private async getOrphanedFiles() {
-    const paths = await FileStorageHelper.list("files/");
-    const files: File[] = await this.repositories.file.loadAll();
+  private static storageKey(contentPath?: string) {
+    if (!contentPath) return "";
+    const key = contentPath.split("?")[0];
+    const i = key.indexOf("files/");
+    return i >= 0 ? key.substring(i) : "";
+  }
+
+  private async getOrphanedFiles(churchId: string, existing: File[]) {
+    const files: File[] = await this.repositories.file.loadForChurch(churchId);
+    const prefixes = new Set<string>();
+    for (const f of existing) {
+      const key = FileController.storageKey(f.contentPath);
+      const slash = key.lastIndexOf("/");
+      if (slash > 0) prefixes.add(key.substring(0, slash + 1));
+    }
+    const paths: string[] = [];
+    for (const prefix of prefixes) {
+      const listed = await FileStorageHelper.list(prefix);
+      paths.push(...listed);
+    }
     for (let i = paths.length - 1; i >= 0; i--) {
       let match = false;
       files.forEach(f => {

--- a/src/controllers/__tests__/BundleController.test.ts
+++ b/src/controllers/__tests__/BundleController.test.ts
@@ -1,0 +1,73 @@
+import "reflect-metadata";
+jest.mock("../LessonsBaseController", () => ({
+  LessonsBaseController: class {
+    repositories: any;
+    json(obj: any, status?: number) { return { obj, status: status ?? 200 }; }
+  }
+}));
+jest.mock("../../helpers", () => ({
+  __esModule: true,
+  Permissions: { lessons: { edit: "lessons.edit" } },
+  FilesHelper: { deleteBundleFolder: jest.fn(), deleteFile: jest.fn(), deleteResourceFolder: jest.fn() }
+}));
+jest.mock("../../helpers/ZipHelper", () => ({ ZipHelper: { zipPendingBundles: jest.fn(async () => {}), setBundlePending: jest.fn(async () => {}) } }));
+
+import { BundleController } from "../BundleController";
+import { ZipHelper } from "../../helpers/ZipHelper";
+
+function makeController(au: any, repos: any) {
+  const controller = new BundleController();
+  (controller as any).actionWrapper = (_req: any, _res: any, action: any) => action(au);
+  (controller as any).repositories = repos;
+  return controller;
+}
+
+describe("BundleController.zipAll", () => {
+  it("rejects users without lessons-edit permission", async () => {
+    const controller = makeController({ churchId: "c1", checkAccess: () => false }, {});
+
+    const res = await (controller as any).zipAll({}, {});
+
+    expect(res.status).toBe(401);
+    expect(ZipHelper.zipPendingBundles).not.toHaveBeenCalled();
+  });
+
+  it("zips only the caller's church pending bundles", async () => {
+    const controller = makeController({ churchId: "c1", checkAccess: () => true }, {});
+
+    await (controller as any).zipAll({}, {});
+
+    expect(ZipHelper.zipPendingBundles).toHaveBeenCalledWith("c1");
+  });
+});
+
+describe("BundleController.clearStuckBundles", () => {
+  it("clears only the caller's church stuck bundles", async () => {
+    const hourAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const ownStuck = { id: "b1", churchId: "c1", pendingUpdate: true, dateModified: hourAgo };
+    const save = jest.fn(async (b: any) => b);
+    const loadPendingUpdate = jest.fn(async () => [ownStuck]);
+    const controller = makeController({ churchId: "c1", checkAccess: () => true }, { bundle: { loadPendingUpdate, save } });
+
+    const res = await (controller as any).clearStuckBundles({}, {});
+
+    expect(loadPendingUpdate).toHaveBeenCalledWith(100, "c1");
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ id: "b1", churchId: "c1", pendingUpdate: false }));
+    expect(res.clearedBundleIds).toEqual(["b1"]);
+  });
+
+  it("does not load or clear another church's zip jobs", async () => {
+    const loadPendingUpdate = jest.fn(async (_limit: number, churchId?: string) => {
+      expect(churchId).toBe("c1");
+      return [];
+    });
+    const save = jest.fn();
+    const controller = makeController({ churchId: "c1", checkAccess: () => true }, { bundle: { loadPendingUpdate, save } });
+
+    const res = await (controller as any).clearStuckBundles({}, {});
+
+    expect(loadPendingUpdate).toHaveBeenCalledWith(100, "c1");
+    expect(save).not.toHaveBeenCalled();
+    expect(res.clearedCount).toBe(0);
+  });
+});

--- a/src/controllers/__tests__/DownloadController.test.ts
+++ b/src/controllers/__tests__/DownloadController.test.ts
@@ -11,9 +11,7 @@ jest.mock("../../helpers", () => ({
   Environment: { hubspotKey: "" },
   MauticHelper: { queueLessonDownload: (...args: any[]) => queueLessonDownload(...args) }
 }));
-jest.mock("../../helpers/HubspotHelper", () => ({
-  HubspotHelper: { lookupCompanByChurchId: jest.fn(), setProperties: jest.fn() }
-}));
+jest.mock("../../helpers/HubspotHelper", () => ({ HubspotHelper: { lookupCompanByChurchId: jest.fn(), setProperties: jest.fn() } }));
 
 import { DownloadController } from "../DownloadController";
 

--- a/src/controllers/__tests__/FileController.test.ts
+++ b/src/controllers/__tests__/FileController.test.ts
@@ -12,6 +12,7 @@ jest.mock("@churchapps/apihelper", () => ({
 }));
 jest.mock("../../helpers", () => ({ __esModule: true, Environment: { fileStore: "disk", contentRoot: "" } }));
 
+import { FileStorageHelper } from "@churchapps/apihelper";
 import { FileController } from "../FileController";
 
 function makeController(au: any) {
@@ -21,25 +22,60 @@ function makeController(au: any) {
 }
 
 describe("FileController.getCleanup", () => {
+  beforeEach(() => {
+    (FileStorageHelper.list as jest.Mock).mockReset().mockResolvedValue([]);
+    (FileStorageHelper.remove as jest.Mock).mockReset();
+  });
+
   it("rejects users without lessons-edit permission", async () => {
     const controller = makeController({ churchId: "c1", checkAccess: () => false });
-    (controller as any).repositories = { file: { cleanUp: jest.fn() } };
+    (controller as any).repositories = { file: { cleanUp: jest.fn(), loadForChurch: jest.fn() } };
 
     const res = await (controller as any).getCleanup({}, {});
 
     expect(res.status).toBe(401);
     expect((controller as any).repositories.file.cleanUp).not.toHaveBeenCalled();
+    expect((controller as any).repositories.file.loadForChurch).not.toHaveBeenCalled();
   });
 
   it("awaits cleanUp and removes orphans for permitted users", async () => {
     const controller = makeController({ churchId: "c1", checkAccess: () => true });
     const cleanUp = jest.fn(async () => {});
-    (controller as any).repositories = { file: { cleanUp, loadAll: jest.fn(async () => []) } };
+    const loadForChurch = jest.fn(async () => []);
+    (controller as any).repositories = { file: { cleanUp, loadForChurch } };
 
     const res = await (controller as any).getCleanup({}, {});
 
-    expect(cleanUp).toHaveBeenCalled();
+    expect(cleanUp).toHaveBeenCalledWith("c1");
     expect(res.paths).toEqual([]);
+  });
+
+  it("does not clean another church's files or storage objects", async () => {
+    (FileStorageHelper.list as jest.Mock).mockImplementation(async (prefix: string) => {
+      if (prefix === "files/") return ["files/other/secret.pdf", "files/lesson/abc/keep.pdf", "files/lesson/abc/orphan.pdf"];
+      if (prefix === "files/lesson/abc/") return ["files/lesson/abc/keep.pdf", "files/lesson/abc/orphan.pdf"];
+      return [];
+    });
+
+    const controller = makeController({ churchId: "c1", checkAccess: () => true });
+    const cleanUp = jest.fn(async () => {});
+    const loadAll = jest.fn(async () => { throw new Error("must not load all churches"); });
+    const ownFiles = [{ id: "f1", churchId: "c1", contentPath: "https://cdn/content/files/lesson/abc/keep.pdf" }];
+    const loadForChurch = jest.fn(async (churchId: string) => {
+      expect(churchId).toBe("c1");
+      return ownFiles;
+    });
+    (controller as any).repositories = { file: { cleanUp, loadForChurch, loadAll } };
+
+    const res = await (controller as any).getCleanup({}, {});
+
+    expect(cleanUp).toHaveBeenCalledWith("c1");
+    expect(cleanUp).toHaveBeenCalledTimes(1);
+    expect(loadAll).not.toHaveBeenCalled();
+    expect(FileStorageHelper.list).not.toHaveBeenCalledWith("files/");
+    expect(FileStorageHelper.remove).not.toHaveBeenCalledWith("files/other/secret.pdf");
+    expect(FileStorageHelper.remove).toHaveBeenCalledWith("files/lesson/abc/orphan.pdf");
+    expect(res.paths).toEqual(["files/lesson/abc/orphan.pdf"]);
   });
 });
 

--- a/src/helpers/ZipHelper.ts
+++ b/src/helpers/ZipHelper.ts
@@ -112,11 +112,11 @@ export class ZipHelper {
     await Repositories.getCurrent().bundle.save(bundle);
   }
 
-  static async zipPendingBundles() {
+  static async zipPendingBundles(churchId?: string) {
     const startTime = Date.now();
     console.log("Starting zipPendingBundles process");
 
-    const bundles = await Repositories.getCurrent().bundle.loadPendingUpdate(5);
+    const bundles = await Repositories.getCurrent().bundle.loadPendingUpdate(5, churchId);
     console.log(`Found ${bundles.length} bundles pending zip update`);
 
     let processed = 0;

--- a/src/repositories/BundleRepository.ts
+++ b/src/repositories/BundleRepository.ts
@@ -39,8 +39,10 @@ export class BundleRepository {
       .orderBy("name").execute() as Bundle[];
   }
 
-  public async loadPendingUpdate(limit: number): Promise<Bundle[]> {
-    return await getDb().selectFrom("bundles").selectAll().where("pendingUpdate", "=", true).limit(limit).execute() as Bundle[];
+  public async loadPendingUpdate(limit: number, churchId?: string): Promise<Bundle[]> {
+    let query = getDb().selectFrom("bundles").selectAll().where("pendingUpdate", "=", true);
+    if (churchId) query = query.where("churchId", "=", churchId);
+    return await query.limit(limit).execute() as Bundle[];
   }
 
   public async loadAll(churchId: string): Promise<Bundle[]> {

--- a/src/repositories/FileRepository.ts
+++ b/src/repositories/FileRepository.ts
@@ -64,15 +64,10 @@ export class FileRepository {
     return await getDb().deleteFrom("files").where("id", "=", id).where("churchId", "=", churchId).execute();
   }
 
-  public async cleanUp(): Promise<any> {
-    return await sql`
-      DELETE FROM files WHERE id NOT IN (
-        SELECT fileId FROM bundles WHERE fileId IS NOT NULL
-        UNION ALL
-        SELECT fileId FROM assets WHERE fileId IS NOT NULL
-        UNION ALL
-        SELECT fileId FROM variants WHERE fileId IS NOT NULL
-      )
-    `.execute(getDb());
+  public async cleanUp(churchId: string): Promise<any> {
+    const referenced = getDb().selectFrom("bundles").select("fileId").where("fileId", "is not", null)
+      .unionAll(getDb().selectFrom("assets").select("fileId").where("fileId", "is not", null))
+      .unionAll(getDb().selectFrom("variants").select("fileId").where("fileId", "is not", null));
+    return await getDb().deleteFrom("files").where("churchId", "=", churchId).where("id", "not in", referenced).execute();
   }
 }

--- a/src/repositories/__tests__/BundleRepository.test.ts
+++ b/src/repositories/__tests__/BundleRepository.test.ts
@@ -1,0 +1,42 @@
+jest.mock("../../db", () => ({ getDb: jest.fn() }));
+jest.mock("../../helpers", () => ({
+  __esModule: true,
+  UniqueIdHelper: { shortId: () => "bundle_gen", isMissing: (id?: string) => !id }
+}));
+
+import { getDb } from "../../db";
+import { BundleRepository } from "../BundleRepository";
+
+const mockedGetDb = getDb as jest.Mock;
+
+const pendingChain = (wheres: any[]) => {
+  const chain: any = {
+    selectAll: () => chain,
+    where: (...args: any[]) => { wheres.push(args); return chain; },
+    limit: () => chain,
+    execute: () => Promise.resolve([])
+  };
+  return chain;
+};
+
+describe("BundleRepository.loadPendingUpdate", () => {
+  it("filters by churchId when provided", async () => {
+    const wheres: any[] = [];
+    mockedGetDb.mockReturnValue({ selectFrom: () => pendingChain(wheres) });
+
+    await new BundleRepository().loadPendingUpdate(5, "c1");
+
+    expect(wheres).toContainEqual(["pendingUpdate", "=", true]);
+    expect(wheres).toContainEqual(["churchId", "=", "c1"]);
+  });
+
+  it("loads all churches when churchId is omitted", async () => {
+    const wheres: any[] = [];
+    mockedGetDb.mockReturnValue({ selectFrom: () => pendingChain(wheres) });
+
+    await new BundleRepository().loadPendingUpdate(5);
+
+    expect(wheres).toContainEqual(["pendingUpdate", "=", true]);
+    expect(wheres.some((w: any[]) => w[0] === "churchId")).toBe(false);
+  });
+});

--- a/src/repositories/__tests__/FileRepository.test.ts
+++ b/src/repositories/__tests__/FileRepository.test.ts
@@ -1,0 +1,24 @@
+jest.mock("../../db", () => ({ getDb: jest.fn() }));
+jest.mock("../../helpers", () => ({
+  __esModule: true,
+  UniqueIdHelper: { shortId: () => "file_gen", isMissing: (id?: string) => !id }
+}));
+
+import { getDb } from "../../db";
+import { FileRepository } from "../FileRepository";
+
+const mockedGetDb = getDb as jest.Mock;
+
+describe("FileRepository.cleanUp", () => {
+  it("deletes unreferenced files only for the given churchId", async () => {
+    const wheres: any[] = [];
+    const sub: any = { select: () => sub, where: () => sub, unionAll: () => sub };
+    const chain: any = { where: (...args: any[]) => { wheres.push(args); return chain; }, execute: () => Promise.resolve([]) };
+    mockedGetDb.mockReturnValue({ deleteFrom: () => chain, selectFrom: () => sub });
+
+    await new FileRepository().cleanUp("c1");
+
+    expect(wheres).toContainEqual(["churchId", "=", "c1"]);
+    expect(wheres.some((w: any[]) => w[0] === "id" && w[1] === "not in")).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`lessons.edit` is a per-church permission, but cleanup and zip HTTP handlers operated on the global file table, the entire `files/` prefix, and every church’s pending zip jobs.

**What changed**
- HTTP `GET /files/cleanup` calls `file.cleanUp(au.churchId)` and only lists S3 prefixes derived from that church’s rows. It no longer calls `file.loadAll()` or `FileStorageHelper.list("files/")`.
- HTTP `GET /bundles/zip`, `GET /bundles/queue/health`, and `POST /bundles/queue/clear-stuck` pass `au.churchId` into `loadPendingUpdate` / `zipPendingBundles`.
- `file.cleanUp` is `WHERE churchId = ?`.
- `loadPendingUpdate(limit, churchId?)` is optional so the scheduled `zipBundles` Lambda stays global (IAM/cron-only, no HTTP event).

**Why this instead of removing the HTTP routes**
The scheduled zip job already exists and should keep processing every church. HTTP callers still need a way to zip or clean *their* church. Scoping those routes is the smaller fix and matches the “HTTP = church, cron = global” split.

**Test**
An editor JWT for church `c1` cannot `cleanUp` another church or `remove` another church’s S3 keys.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ee51a67-2767-4677-bcb9-401f366c1db6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ee51a67-2767-4677-bcb9-401f366c1db6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

